### PR TITLE
Standardise tables

### DIFF
--- a/Dashboard Data Transfer/Transfer scripts/transfer_labdata.R
+++ b/Dashboard Data Transfer/Transfer scripts/transfer_labdata.R
@@ -1,11 +1,11 @@
-# Dashboard data transfer for Lab Data 
+# Dashboard data transfer for Lab Data
 # Sourced from ../dashboard_data_transfer.R
 
 ##### 6. Lab Data
 
 
 
-i_labdata <- read_all_sheets(glue("Input data/Lab_Data_HPS_{format(report_date-2, format='%m%d')}_test.xlsx"))
+i_labdata <- read_all_sheets(glue("Input data/Lab_Data_HPS_{format(report_date-2, format='%m%d')}.xlsx"))
 i_barchart <- read_csv_with_options(glue("Input data/cases_agegrp_chart_data_{format(as.Date((report_date-2), format='%Y%m%d'), format='%m%d')}.csv"))
 
 o_labcases <- read.csv(glue("{output_folder}/LabCases.csv"), header = TRUE, stringsAsFactors = FALSE, check.names=FALSE)
@@ -20,17 +20,17 @@ g_labcases <- i_labdata$`Cumulative confirmed cases`[,1:3] %>% tail(-1)
 
 #names(g_labcases) <- g_labcases[1,]
 
-g_labcases %<>% 
-#  transform(Date = excel_numeric_to_date(as.numeric(as.character(Date)), date_system = "modern") ) %>% 
-  dplyr::rename(NumberCasesperDay = `Number of cases per day`) 
+g_labcases %<>%
+#  transform(Date = excel_numeric_to_date(as.numeric(as.character(Date)), date_system = "modern") ) %>%
+  dplyr::rename(NumberCasesperDay = `Number of cases per day`)
 
 g_labcases$NumberCasesperDay <- as.numeric(g_labcases$NumberCasesperDay)
 g_labcases$Cumulative <- as.numeric(g_labcases$Cumulative)
 
 pop_grandtotal <- i_population$pop_number[i_population$age_group == "All" & i_population$sex == "Total"]
 
-g_labcases %<>% 
-  mutate(Average7 = zoo::rollmean(NumberCasesperDay, k = 7, fill = NA, align="right")) %>% 
+g_labcases %<>%
+  mutate(Average7 = zoo::rollmean(NumberCasesperDay, k = 7, fill = NA, align="right")) %>%
   mutate(CumulativeRatePer100000 = 100000 * Cumulative / pop_grandtotal)
 
 write.csv(g_labcases, glue("Test output/LabCases.csv"), row.names = FALSE)
@@ -45,24 +45,24 @@ g_lagesex <- i_labdata$`Age group and sex` %>% head(-4)
 
 #names(g_lagesex) <- g_lagesex[1,]
 
-g_lagesex %<>% 
+g_lagesex %<>%
   dplyr::rename(Total = `All Sex`,
-                age_group = `Age group (years)`) %>% 
+                age_group = `Age group (years)`) %>%
   select(-`%agegroup`)
 
 g_lagesex$age_group[g_lagesex$age_group == "Total"] <- "All"
 
-g_lagesex %<>% 
-  reshape2::melt(id=c("age_group"), variable="sex") %>% 
-  dplyr::rename(number = value) %>% 
+g_lagesex %<>%
+  reshape2::melt(id=c("age_group"), variable="sex") %>%
+  dplyr::rename(number = value) %>%
   select(sex, age_group, number)
 
 g_lagesex$number <- as.numeric(g_lagesex$number)
 
-g_lagesex %<>% 
-  left_join(i_population, by=c("age_group", "sex")) %>% 
-  mutate(rate = 100000*number/pop_number) %>% 
-  select(sex, age_group, number, rate) %>% 
+g_lagesex %<>%
+  left_join(i_population, by=c("age_group", "sex")) %>%
+  mutate(rate = 100000*number/pop_number) %>%
+  select(sex, age_group, number, rate) %>%
   arrange(factor(sex, levels = c("Male", "Female", "Unknown")))
 
 g_lagesex$age_group[g_lagesex$age_group == "All"] <- "All Ages"
@@ -82,26 +82,25 @@ g_lsimd <- i_labdata$SIMD
 g_lsimd$`SIMD Quintile`[g_lsimd$`SIMD Quintile` == "Missing"] <- "Unknown"
 
 
-g_lsimd %<>% 
-  tail(-1) %>% 
-  drop_na(`SIMD Quintile`) %>% 
-  subset(`SIMD Quintile` != "Total") %>% 
+g_lsimd %<>%
+  drop_na(`SIMD Quintile`) %>%
+  subset(`SIMD Quintile` != "Total") %>%
   dplyr::rename(cases_pc = `% cases per quintile`,
                 cases = Cases,
                 SIMD = `SIMD Quintile`)
-  
+
 
 write.csv(g_lsimd, glue("Test output/LabCases_SIMD.csv"), row.names = FALSE)
 
 rm(g_lsimd)
-  
+
 
 ### d) LabCases_Age
 
-o_barchart <- i_barchart %>% 
+o_barchart <- i_barchart %>%
   dplyr::rename(Age = age_group,
                 Cases = count,
-                Date = `Week ending`) %>% 
+                Date = `Week ending`) %>%
   select(Date, Age, Cases)
 
 write.csv(o_barchart, glue("Test output/LabCases_Age.csv"), row.names=FALSE)

--- a/app_data_preparation.R
+++ b/app_data_preparation.R
@@ -306,20 +306,11 @@ saveRDS(HCW_Psychiatry, "data/HCW_Psychiatry.rds")
 # Ethnicity -----------------------------------------------------------------
 
 Ethnicity <- read_csv("data/Ethnicity.csv")
-Ethnicity <- Ethnicity %>%
-  mutate(Percentage = Percentage*100)%>%
-  mutate_if(is.numeric, round, 2)
+Ethnicity <- Ethnicity
 saveRDS(Ethnicity, "data/Ethnicity.rds")
 
 Ethnicity_Chart <- read_csv("data/Ethnicity_Chart.csv")
-Ethnicity_Chart <- Ethnicity_Chart %>%
-  mutate(White_p = White_p*100,
-         `Black/Caribbean/African_p` = `Black/Caribbean/African_p`*100,
-         `South Asian_p` = `South Asian_p`*100,
-         Chinese_p = Chinese_p*100,
-         Other_p = Other_p*100,
-         `Not Available_p` = `Not Available_p`*100) %>%
-  mutate_if(is.numeric, round, 2)
+Ethnicity_Chart <- Ethnicity_Chart
 saveRDS(Ethnicity_Chart, "data/Ethnicity_Chart.rds")
 
 #### Care Homes ----------------------------------------------------------------

--- a/app_data_preparation.R
+++ b/app_data_preparation.R
@@ -108,7 +108,11 @@ saveRDS(Cases_Adm, "data/Cases_Adm.rds")
 Cases_Age <- read_csv("data/Cases_AgeGrp.csv") %>%
   group_by(Date) %>%
   mutate(Percent = round_half_up(100*Cases/sum(Cases), 2)) %>%
-  select(-Cases)
+  select(-Cases) %>%
+  # Removing square brackets
+  dplyr::mutate(Age = gsub(pattern = "\\[|\\]",
+                                   replacement = "",
+                                   Age))
 saveRDS(Cases_Age, "data/Cases_AgeGrp.rds")
 
 Prop_Adm_AgeGrp = read_csv("data/Prop_Admitted_AgeGrp.csv")

--- a/shiny_app/functions_tables.R
+++ b/shiny_app/functions_tables.R
@@ -33,15 +33,20 @@ datatab_table <- function(input_data_table,
 
   table_colnames  <-  gsub("_", " ", colnames(input_data_table))
 
-  if(!is.null(add_separator_cols)){
+  # Add column formatting
 
     for (i in add_separator_cols){
-      input_data_table[i] <- unlist(map(input_data_table[[i]], format_cols))
+      input_data_table[i] <- apply(input_data_table[i], MARGIN=1, FUN=format_cols)
     }
 
-  #  input_data_table[add_separator_cols] <- input_data_table[add_separator_cols] %>% map_dfc(format_cols)
+    for (i in add_separator_cols_1dp){
+      input_data_table[i] <- apply(input_data_table[i], MARGIN=1, FUN=format_cols, dp=1)
+    }
 
-  }
+    for (i in add_percentage_cols){
+      input_data_table[i] <- apply(input_data_table[i], MARGIN=1, FUN=format_cols, dp=1, perc=T)
+    }
+
 
   if(flip_order){
     tab_order <- list(list(0, "asc"))

--- a/shiny_app/functions_tables.R
+++ b/shiny_app/functions_tables.R
@@ -4,28 +4,28 @@
 
 # Data table for Data tab
 
-datatab_table <- function(input_data_table, 
+datatab_table <- function(input_data_table,
                           add_separator_cols = NULL, # with , separator and 0dp
                           add_separator_cols_1dp = NULL, # with , separator and 1dp
                           add_percentage_cols = NULL, # with % symbol and 2dp
                           maxrows = 14, # max rows displayed on page
                           flip_order = FALSE, # Flip order of rows
                           highlight_column = NULL # Column to highlight specific entries based off
-                          ){ 
-  
-  
+                          ){
+
+
   # Remove the underscore from column names in the table
-  
+
   table_colnames  <-  gsub("_", " ", colnames(input_data_table))
-  
+
   if(flip_order){
     tab_order <- list(list(0, "asc"))
   } else {
     tab_order <- list(list(0, "desc"))
   }
-  
+
   dt <- DT::datatable(input_data_table, style = 'bootstrap',
-                
+
                 class = 'table-bordered table-condensed',
                 rownames = FALSE,
                 options = list(pageLength = maxrows,
@@ -36,33 +36,33 @@ datatab_table <- function(input_data_table,
                                  "$(this.api().table().header()).css({'background-color': '#3F3685', 'color': 'white'});",
                                  "}"), # Make header phs-purple
                                order = tab_order),
-                
+
                 filter = "top",
-                colnames = table_colnames) %>% 
+                colnames = table_colnames) %>%
     formatStyle(
-      highlight_column, target="row", 
-      backgroundColor = styleEqual(c("Cumulative"), 
+      highlight_column, target="row",
+      backgroundColor = styleEqual(c("Cumulative"),
                                    c(phs_colours("phs-magenta"))), # highlight Scotland rows in phs-magenta
       fontWeight = styleEqual(c("Cumulative"), c("bold")),
       color = styleEqual(c("Cumulative"), c("white"))
     )
-  
+
   if(!is.null(add_separator_cols)){
     dt %<>% formatCurrency(add_separator_cols, '', digits=0) ## hack to add thousands separator
   }
-  
+
   if(!is.null(add_separator_cols_1dp)){
     dt %<>% formatCurrency(add_separator_cols_1dp, '', digits=1) ## hack to add thousands separator
   }
-  
+
   if(!is.null(add_percentage_cols)){
-    dt %<>% formatCurrency(add_percentage_cols, mark=",", digits=2, currency="%", before=FALSE) 
+    dt %<>% formatCurrency(add_percentage_cols, mark=",", digits=1, currency="%", before=FALSE)
   }
-  
-  
+
+
   return(dt)
-  
-  
+
+
 }
 
 
@@ -72,16 +72,16 @@ byboard_data_table <- function(input_data_table,
                                add_separator_cols=NULL, # Column indices to add thousand separators to
                                rows_to_display=14,
                                flip_order=FALSE){ # Number of Boards + 1 for Scotland
-  
+
   if(flip_order){
     tab_order <- list(list(0, "asc"))
   } else {
     tab_order <- list(list(0, "desc"))
   }
-  
+
   # Remove the underscore from column names in the table
   table_colnames  <-  gsub("_", " ", colnames(input_data_table))
-  
+
   dt <- DT::datatable(input_data_table, style = 'bootstrap',
                 class = 'table-bordered table-condensed',
                 rownames = FALSE,
@@ -95,20 +95,20 @@ byboard_data_table <- function(input_data_table,
                                  "}") # Make header phs-purple
                 ),
                 filter = "top",
-                colnames = table_colnames) %>% 
+                colnames = table_colnames) %>%
     formatStyle(
-      board_name_column, target="row", 
-      backgroundColor = styleEqual(c("Scotland", "Total", "All"), 
+      board_name_column, target="row",
+      backgroundColor = styleEqual(c("Scotland", "Total", "All"),
                                    c(phs_colours("phs-magenta"),phs_colours("phs-magenta"),phs_colours("phs-magenta"))), # highlight Scotland rows in phs-magenta
       fontWeight = styleEqual(c("Scotland", "Total", "All"), c("bold", "bold", "bold")),
       color = styleEqual(c("Scotland", "Total", "All"), c("white", "white", "white"))
     )
-  
+
   if(!is.null(add_separator_cols)){
     dt %<>% formatCurrency(add_separator_cols, '', digits=0) ## hack to add thousands separator
   }
-  
-  
+
+
   return(dt)
 
 }

--- a/shiny_app/functions_tables.R
+++ b/shiny_app/functions_tables.R
@@ -2,17 +2,21 @@
 
 ###############################################
 
-## Column formatting functions
-
-format_cols <- function(x, dp=0, perc=F){
+## Function to format a given entry in a table
+format_entry <- function(x, dp=0, perc=F){
+  # x (numeric, char): entry
+  # dp (int): number of decimal places
+  # perc (bool): whether to add % afterwards
 
   # First strip any existing commas and whitespace out
   x <- gsub(",", "", x)
   x <- gsub(" ", "", x)
 
+  # Try to convert entry to numeric, if failed return NULL
   numx <- tryCatch(as.numeric(x),
            warning = function(w) NULL)
 
+  # Format entry if numeric
   if (!is.null(numx)){
     numx <- formatC(numx, format="f", big.mark = ",", digits=dp)
     if (perc){
@@ -20,6 +24,7 @@ format_cols <- function(x, dp=0, perc=F){
     }
     return (numx)
   } else {
+    # If entry cannot be converted to numeric, return original entry i.e. "*"
     return(x)
   }
 }
@@ -43,15 +48,15 @@ datatab_table <- function(input_data_table,
   # Add column formatting
 
     for (i in add_separator_cols){
-      input_data_table[i] <- apply(input_data_table[i], MARGIN=1, FUN=format_cols)
+      input_data_table[i] <- apply(input_data_table[i], MARGIN=1, FUN=format_entry)
     }
 
     for (i in add_separator_cols_1dp){
-      input_data_table[i] <- apply(input_data_table[i], MARGIN=1, FUN=format_cols, dp=1)
+      input_data_table[i] <- apply(input_data_table[i], MARGIN=1, FUN=format_entry, dp=1)
     }
 
     for (i in add_percentage_cols){
-      input_data_table[i] <- apply(input_data_table[i], MARGIN=1, FUN=format_cols, dp=1, perc=T)
+      input_data_table[i] <- apply(input_data_table[i], MARGIN=1, FUN=format_entry, dp=1, perc=T)
     }
 
 
@@ -109,7 +114,7 @@ byboard_data_table <- function(input_data_table,
   # Add column formatting
 
   for (i in add_separator_cols){
-    input_data_table[i] <- apply(input_data_table[i], MARGIN=1, FUN=format_cols)
+    input_data_table[i] <- apply(input_data_table[i], MARGIN=1, FUN=format_entry)
   }
 
   dt <- DT::datatable(input_data_table, style = 'bootstrap',

--- a/shiny_app/functions_tables.R
+++ b/shiny_app/functions_tables.R
@@ -5,8 +5,15 @@
 ## Column formatting functions
 
 format_cols <- function(x, dp=0, perc=F){
-  numx <- as.numeric(x)
-  if (!is.na(numx)){
+
+  # First strip any existing commas and whitespace out
+  x <- gsub(",", "", x)
+  x <- gsub(" ", "", x)
+
+  numx <- tryCatch(as.numeric(x),
+           warning = function(w) NULL)
+
+  if (!is.null(numx)){
     numx <- formatC(numx, format="f", big.mark = ",", digits=dp)
     if (perc){
       numx <- paste0(numx, "%")
@@ -77,23 +84,6 @@ datatab_table <- function(input_data_table,
       color = styleEqual(c("Cumulative"), c("white"))
     )
 
-
- # if(!is.null(add_separator_cols_1dp))
-
- #   for (i in add_separator_cols_1dp){
- #     dt[i] <- map(dt[i], format_cols, dp=1)
- #   }
-# }
-
- # if(!is.null(add_percentage_cols)){
-#
- #   for (i in add_percentage_cols){
- #     dt[i] <- map(dt[i], format_cols, dp=1, perc=T)
-  #  }
-
-#  }
-
-
   return(dt)
 
 
@@ -116,6 +106,12 @@ byboard_data_table <- function(input_data_table,
   # Remove the underscore from column names in the table
   table_colnames  <-  gsub("_", " ", colnames(input_data_table))
 
+  # Add column formatting
+
+  for (i in add_separator_cols){
+    input_data_table[i] <- apply(input_data_table[i], MARGIN=1, FUN=format_cols)
+  }
+
   dt <- DT::datatable(input_data_table, style = 'bootstrap',
                 class = 'table-bordered table-condensed',
                 rownames = FALSE,
@@ -137,11 +133,6 @@ byboard_data_table <- function(input_data_table,
       fontWeight = styleEqual(c("Scotland", "Total", "All"), c("bold", "bold", "bold")),
       color = styleEqual(c("Scotland", "Total", "All"), c("white", "white", "white"))
     )
-
-  if(!is.null(add_separator_cols)){
-    dt %<>% formatCurrency(add_separator_cols, '', digits=0) ## hack to add thousands separator
-  }
-
 
   return(dt)
 

--- a/shiny_app/functions_tables.R
+++ b/shiny_app/functions_tables.R
@@ -2,6 +2,21 @@
 
 ###############################################
 
+## Column formatting functions
+
+format_cols <- function(x, dp=0, perc=F){
+  numx <- as.numeric(x)
+  if (!is.na(numx)){
+    numx <- formatC(numx, format="f", big.mark = ",", digits=dp)
+    if (perc){
+      numx <- paste0(numx, "%")
+    }
+    return (numx)
+  } else {
+    return(x)
+  }
+}
+
 # Data table for Data tab
 
 datatab_table <- function(input_data_table,
@@ -17,6 +32,16 @@ datatab_table <- function(input_data_table,
   # Remove the underscore from column names in the table
 
   table_colnames  <-  gsub("_", " ", colnames(input_data_table))
+
+  if(!is.null(add_separator_cols)){
+
+    for (i in add_separator_cols){
+      input_data_table[i] <- unlist(map(input_data_table[[i]], format_cols))
+    }
+
+  #  input_data_table[add_separator_cols] <- input_data_table[add_separator_cols] %>% map_dfc(format_cols)
+
+  }
 
   if(flip_order){
     tab_order <- list(list(0, "asc"))
@@ -47,17 +72,21 @@ datatab_table <- function(input_data_table,
       color = styleEqual(c("Cumulative"), c("white"))
     )
 
-  if(!is.null(add_separator_cols)){
-    dt %<>% formatCurrency(add_separator_cols, '', digits=0) ## hack to add thousands separator
-  }
 
-  if(!is.null(add_separator_cols_1dp)){
-    dt %<>% formatCurrency(add_separator_cols_1dp, '', digits=1) ## hack to add thousands separator
-  }
+ # if(!is.null(add_separator_cols_1dp))
 
-  if(!is.null(add_percentage_cols)){
-    dt %<>% formatCurrency(add_percentage_cols, mark=",", digits=1, currency="%", before=FALSE)
-  }
+ #   for (i in add_separator_cols_1dp){
+ #     dt[i] <- map(dt[i], format_cols, dp=1)
+ #   }
+# }
+
+ # if(!is.null(add_percentage_cols)){
+#
+ #   for (i in add_percentage_cols){
+ #     dt[i] <- map(dt[i], format_cols, dp=1, perc=T)
+  #  }
+
+#  }
 
 
   return(dt)


### PR DESCRIPTION
Addresses #54 
The idea is to change the format of the csv files and update dashboard data transfer scripts accordingly such that the tables in the dashboard look better. Specifically

- [x] Fix bug where SIMD1 not displayed for positive PCR cases by deprivation
- [x] Change % formatting in tables to 1dp
- [x] Remove [] around ages for cases by age group
- [x] Make sure * appears for suppressed values rather than NA