### PR TITLE
Move NHS24 contacts to archive

### DIFF
--- a/Dashboard Data Transfer/dashboard_data_transfer.R
+++ b/Dashboard Data Transfer/dashboard_data_transfer.R
@@ -77,9 +77,6 @@ i_population$age_group <- sapply(i_population$age_group, function(x) str_remove_
 # o: output - dashboard output folder updated last week
 # g: generated in this script - for replainscing output
 
-##### 1. NHS24
-source("Transfer scripts/transfer_NHS24.R")
-
 ##### 2. ICU
 source("Transfer scripts/transfer_ICU.R")
 
@@ -91,12 +88,6 @@ source("Transfer scripts/transfer_admissions.R")
 
 ##### 6. Lab Data
 source("Transfer scripts/transfer_labdata.R")
-
-##### 7. NHS24 Community
-source("Transfer scripts/transfer_NHS24community.R")
-
-##### 8. NHS Inform
-source("Transfer scripts/transfer_NHSInform.R")
 
 ##### 11. Care Homes
 source("Transfer scripts/transfer_carehomes.R")
@@ -130,8 +121,17 @@ source("Transfer scripts/transfer_carehomes_sg.R")
 
 ##### Archived -----
 
+##### 1. NHS24
+#source("Transfer scripts/transfer_NHS24.R")
+
 ##### 3. Community Hubs and Assessment
 #source("Transfer scripts/transfer_commhubsassessment.R")
+
+##### 7. NHS24 Community
+#source("Transfer scripts/transfer_NHS24community.R")
+
+##### 8. NHS Inform
+#source("Transfer scripts/transfer_NHSInform.R")
 
 ##### 9. Community Testing
 #source("Transfer scripts/transfer_communitytesting.R")

--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -4,7 +4,7 @@
 ## Data extraction dates ----
 
 #publication date
-pub_date <- as.Date("2022-06-22")
+pub_date <- as.Date("2022-06-29")
 
 Labcases_date <- format(pub_date - 3, "%d %B %Y")
 ICU_date <- format(pub_date - 4, "%d %B %Y")
@@ -208,10 +208,10 @@ severe_illness_list <- c("Hospital Admissions" = "Admissions",
                          "Hospital Admissions by Ethnicity" = "Ethnicity_Chart",
                          "ICU Admissions" = "ICU")
 
-surveillance_list <- c("NHS24 Contacts" = "NHS24",
-                       "Scottish Ambulance Service" = "SAS")
+surveillance_list <- c("Scottish Ambulance Service" = "SAS")
 
-surveillance_archive_list <- c("Community Hubs and Assessment Centres" = "AssessmentHub")
+surveillance_archive_list <- c("NHS24 Contacts" = "NHS24",
+                               "Community Hubs and Assessment Centres" = "AssessmentHub")
 
 CTdata_list_chart_tab <- c("Contact Tracing time performance %",
                             "Contact Tracing time performance cases",
@@ -251,18 +251,18 @@ severe_illness_data_list <- c("Hospital admissions" = "Admissions",
                               "ICU admissions" = "ICU",
                               "ICU admissions by age and sex" = "ICU_AgeSex")
 
-surveillance_data_list <- c("NHS24 contacts" = "NHS24",
-                            "NHS24 contacts by age and sex" = "NHS24_AgeSex",
-                            "NHS24 contacts by deprivation" = "NHS24_SIMD",
-                            "NHS Inform hits" = "NHS24_inform",
-                            "NHS24 self help guides" = "NHS24_selfhelp",
-                            "NHS24 community outcomes"  = "NHS24_community",
-                            "Scottish Ambulance Service" = "SAS",
+surveillance_data_list <- c("Scottish Ambulance Service" = "SAS",
                             "Scottish Ambulance Service by age and sex" = "SAS_AgeSex",
                             "Scottish Ambulance Service by deprivation" = "SAS_SIMD",
                             "Scottish Ambulance Service - all incidents" = "SAS_all")
 
-surveillance_archive_data_list <- c("Community hubs and assessment centres" = "AssessmentHub",
+surveillance_archive_data_list <- c("NHS24 contacts" = "NHS24",
+                                    "NHS24 contacts by age and sex" = "NHS24_AgeSex",
+                                    "NHS24 contacts by deprivation" = "NHS24_SIMD",
+                                    "NHS Inform hits" = "NHS24_inform",
+                                    "NHS24 self help guides" = "NHS24_selfhelp",
+                                    "NHS24 community outcomes"  = "NHS24_community",
+                                    "Community hubs and assessment centres" = "AssessmentHub",
                                     "Community hubs and assessment centres by age" = "AssessmentHub_AgeSex",
                                     "Community hubs and assessment centres by deprivation" = "AssessmentHub_SIMD")
 

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -62,8 +62,8 @@ tagList(  #needed for shinyjs
                       ),
                # Surveillance
                column(4, class="landing-page-column",
-                     lp_main_box(button_name = 'jump_to_surveillance', title_box = "Surveillance",
-                                    description = 'Statistics from NHS24 and Scottish Ambulance Service'))
+                     lp_main_box(button_name = 'jump_to_surveillance', title_box = "SAS",
+                                    description = 'Statistics from Scottish Ambulance Service'))
              ), # fluid row close
              # End of second row
              br(),
@@ -89,7 +89,7 @@ tagList(  #needed for shinyjs
                                             title_box = "Targeted community testing")),
                         column(3, class="landing-page-column",
                                lp_about_box(button_name = 'jump_to_surveillance_archive',
-                                            title_box = "Community hubs and assessment"),
+                                            title_box = "Archived surveillance"),
                                lp_about_box(button_name = 'jump_to_travel',
                                             title_box = "Travel outside Scotland"))
              ), #Fluidrow bracket
@@ -487,8 +487,8 @@ tagList(  #needed for shinyjs
     ), # page bracket
     #################### Surveillance -----
     navbarMenu(
-      title = "Surveillance",
-      icon = icon("desktop"),
+      title = "Scottish Ambulance Service",
+      icon = icon("truck-medical", verify_fa=FALSE),
       tabPanel(
         title = "Charts",
         icon = icon("chart-area"),
@@ -600,7 +600,7 @@ tagList(  #needed for shinyjs
       icon = icon("floppy-disk", verify_fa=F),
       #################### Surveillance -----
         tabPanel(
-          title = "Community hubs & assessment",
+          title = "Archived surveillance",
           icon = icon("chart-area"),
           value = "SurveillanceArchive",
           wellPanel(
@@ -609,7 +609,7 @@ tagList(  #needed for shinyjs
                        radioGroupButtons("measure_select_surveillance_archive",
                                          label = "Select the data you want to explore.",
                                          choices = surveillance_archive_list,
-                                         status = "primary",
+                                         status = "btn",
                                          selected = surveillance_archive_list[[1]],
                                          direction = "vertical",
                                          justified = T))),
@@ -630,7 +630,7 @@ tagList(  #needed for shinyjs
         ),
         #################### Data ----
         tabPanel(
-          title = "Community hubs & assessment data",
+          title = "Archived surveillance data",
           icon = icon("table"),
           value = "SurveillanceArchiveData",
           p("This section allows you to view the data in table format.

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -26,6 +26,9 @@ tagList(  #needed for shinyjs
              p("Since the start of the COVID-19 outbreak Public Health Scotland (PHS) has been working closely
                with Scottish Government and health and care colleagues in supporting the surveillance and monitoring
                of COVID-19 amongst the population."),
+             p(strong("Please note: we are aware that this week's figures are likely to be an under
+                      report and cover less than a 7-day period. This is due to a data processing issue
+                      since 9am on 25 June 2022.")),
              h3("What's on the dashboard?"),
              p("You can navigate around the dashboard using the tabs on the top banner, or by clicking one of the boxes below."),
              # 1st row of boxes
@@ -395,7 +398,7 @@ tagList(  #needed for shinyjs
       tabPanel(
         title = "Care homes COVID-19 cases",
         icon = icon("home"),
-        value = "CareHomesTesting",
+        value = "PopInterest",
         fluidRow(br()),
         actionButton('jump_to_notes_pop_interest', 'Go to data notes'),
 


### PR DESCRIPTION
- Created archive surveillance subtab in archive which now includes community hubs & NHS24
- Renamed the existing surveillance tab to just SAS as this is all that's left
- Updated the landing page so the button descriptions fit this change
- Fixed broken populations of interest landing page button