### PR TITLE
Automatic copying from new data folder

### DIFF
--- a/Dashboard Data Transfer/Transfer scripts/transfer_admissions.R
+++ b/Dashboard Data Transfer/Transfer scripts/transfer_admissions.R
@@ -193,7 +193,7 @@ rm(g_adm_agegroup, adm_path)
 
 ### f) simd trend
 
-i_simd_trend <- read_csv_with_options(glue(input_data, "Hospital Admissions/{format(report_date-2, format='%Y%m%d')} - simd summary_TEST.csv"))
+i_simd_trend <- read_csv_with_options(glue(input_data, "/{format(report_date-2, format='%Y%m%d')} - simd summary.csv"))
 
 g_simd_trend <- i_simd_trend %>%
   dplyr::rename(WeekEnding = date, NumberOfAdmissions = Total, SIMD = simd, ProvisionalOrStable = provisional) %>%

--- a/Dashboard Data Transfer/Transfer scripts/transfer_los.R
+++ b/Dashboard Data Transfer/Transfer scripts/transfer_los.R
@@ -2,7 +2,7 @@
 
 
 
-los = read_csv_with_options(glue(input_data, "Hospital Admissions/{format(report_date -2,'%Y-%m-%d')}_LOS Table Dashboard.csv"))
+los = read_csv_with_options(glue(input_data, "/{format(report_date -2,'%Y-%m-%d')}_LOS Table Dashboard.csv"))
 
 names(los) = c("Age Group", "Week Ending", "Length of Stay", "n", "prop")
 

--- a/Dashboard Data Transfer/dashboard_data_transfer.R
+++ b/Dashboard Data Transfer/dashboard_data_transfer.R
@@ -72,6 +72,18 @@ i_population$age_group[i_population$age_group == "total"] <- "All"
 i_population$age_group <- sapply(i_population$age_group, function(x) str_remove(x, "years"))
 i_population$age_group <- sapply(i_population$age_group, function(x) str_remove_all(x, " "))
 
+
+# Refresh input data folder ----
+# Clear input data
+purrr::walk(list.files(path=input_data, full.names=TRUE), unlink, recursive=TRUE)
+
+# Copy new files across from data folder
+data_folder <- glue("/conf/C19_Test_and_Protect/Test & Protect - Warehouse/",
+                                    "Weekly Data Folders/{report_date}/Data")
+
+data_files = list.files(path=data_folder, recursive=TRUE, full.names=TRUE)
+purrr::walk(data_files, file.copy, to = input_data, recursive=TRUE, overwrite=TRUE)
+
 # Key within each transfer file:
 # ------------------------------
 # i: input files - from weekly report data folder copied across


### PR DESCRIPTION
- Data are stored at new filepath on the stats drive
- Now we can automatically copy the data across every time `dashboard_data_transfer.R` is run
- Input data folder structure is flattened so no longer separate Hospital Admissions sub folder
- In the future we could dispense with copying the data across to Input data but keeping for now so that the dashboard data input structure remains intact